### PR TITLE
change dependency on omniauth-oauth2

### DIFF
--- a/omniauth-clever.gemspec
+++ b/omniauth-clever.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency 'omniauth-oauth2', '~> 1.1.1'
+  gem.add_runtime_dependency 'omniauth-oauth2', '>= 1.1.1'
 end


### PR DESCRIPTION
The dependency on omniauth-oauth2 ~> 1.1.1 prevents the usage of this gem with omniauth-oauth2 version 1.2 (which I need for other omniauth providers such as microsoft and facebook). I tested Clever Instant Login with omniauth-oauth2 1.2.0 and it works so I propose changing the dependency to 1.1.1 and up.
