### PR TITLE
Make omniauth-clever compatible with present-day Clever OAuth 2.0 implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # OmniAuth Clever
 
-Unofficial OmniAuth strategy for [Clever SSO OAuth2](https://clever.com/developers/docs/oauth) integration.
+Unofficial OmniAuth strategy for [Clever SSO OAuth2](https://dev.clever.com/sso) integration.
 
 ## Installation
 
 Add the gem to your application's Gemfile:
 
-    gem 'omniauth-clever', '~> 1.1.0'
+    gem 'omniauth-clever', '~> 1.2.0'
 
 And then execute:
 
@@ -44,6 +44,10 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 end
 ```
 
+## Testing
+
+This strategy can be and has been tested with the [omniauth-test-harness](https://github.com/PracticallyGreen/omniauth-test-harness).
+
 ## Contributing
 
 1. Fork it
@@ -61,7 +65,7 @@ MIT. See LICENSE.txt.
 Thank you to the [Clever](https://github.com/Clever/) team for their awesome
 product and always being helpful with any issues. Thank you to [Think Through
 Math](https://github.com/thinkthroughmath) for dedicating time for the tech
-team to make open source contributions such as this.
+team to make open source contributions such as this. Thank you to [StudyPad] for helping bringing the strategy up to date.
 
 And, of course. thank you to [Omniauth](https://github.com/intridea/omniauth)
 for making it so easy create this gem!

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ end
 
 ## Configuring
 
-To be able to set the optional `clever_landing` or `dev` parameters on a
-per-request basis by passing these params to your `/auth/clever` url, use
+To be able to set the optional `district_id` parameter on a
+per-request basis, passing this params to your `/auth/clever` url, use
 this in the initializer instead:
 
 ```ruby
@@ -39,8 +39,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   provider :clever, ENV['CLEVER_CLIENT_ID'], ENV['CLEVER_CLIENT_SECRET'],
            :setup => lambda { |env|
              params = Rack::Utils.parse_query(env['QUERY_STRING'])
-             env['omniauth.strategy'].options[:client_options][:clever_landing] = params['clever_landing']
-             env['omniauth.strategy'].options[:client_options][:dev] = params['dev']
+             env['omniauth.strategy'].options[:client_options][:district_id] = params['district_id']
            }
 end
 ```

--- a/lib/omniauth/clever/version.rb
+++ b/lib/omniauth/clever/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Clever
-    VERSION = "1.1.0"
+    VERSION = "1.2.0"
   end
 end

--- a/lib/omniauth/strategies/clever.rb
+++ b/lib/omniauth/strategies/clever.rb
@@ -8,24 +8,20 @@ module OmniAuth
 
       option :client_options, {
         :site          => 'https://api.clever.com',
-        :authorize_url => 'https://account.clever.com/oauth/authorize',
-        :token_url     => 'https://api.clever.com/oauth/token'
+        :authorize_url => 'https://clever.com/oauth/authorize',
+        :token_url     => 'https://clever.com/oauth/tokens'
       }
 
       def authorize_params
         super.tap do |params|
           params[:scope] = 'read_only'
-          params[:clever_landing] = options.client_options.clever_landing || 'admin'
-          if options.client_options.dev
-            params[:dev] = options.client_options.dev
-          end
+          params[:clever_landing] = options.client_options.fetch(:clever_landing, 'admin')
         end
       end
 
       def token_params
-        username_password = options.client_secret + ":"
         super.tap do |params|
-          params[:headers] = {'Authorization' => "Basic #{Base64.encode64(username_password)}"}
+          params[:headers] = {'Authorization' => "Basic #{Base64.strict_encode64("#{options.client_id}:#{options.client_secret}")}"}
         end
       end
 

--- a/lib/omniauth/strategies/clever.rb
+++ b/lib/omniauth/strategies/clever.rb
@@ -12,13 +12,6 @@ module OmniAuth
         :token_url     => 'https://clever.com/oauth/tokens'
       }
 
-      def authorize_params
-        super.tap do |params|
-          params[:scope] = 'read_only'
-          params[:clever_landing] = options.client_options.fetch(:clever_landing, 'admin')
-        end
-      end
-
       def token_params
         super.tap do |params|
           params[:headers] = {'Authorization' => "Basic #{Base64.strict_encode64("#{options.client_id}:#{options.client_secret}")}"}

--- a/omniauth-clever.gemspec
+++ b/omniauth-clever.gemspec
@@ -6,11 +6,11 @@ require 'omniauth/clever/version'
 Gem::Specification.new do |gem|
   gem.name          = "omniauth-clever"
   gem.version       = Omniauth::Clever::VERSION
-  gem.authors       = ["Carol Nichols"]
-  gem.email         = ["cnichols@thinkthroughmath.com"]
-  gem.description   = %q{Unofficial OmniAuth strategy for clever.com SSO OAuth2 integration}
+  gem.authors       = ["Carol Nichols", "Swati Aggarwal"]
+  gem.email         = ["cnichols@thinkthroughmath.com", "swati.aggarwal2412@gmail.com"]
+  gem.description   = %q{OmniAuth strategy for clever.com SSO OAuth2 integration}
   gem.summary       = %q{The unofficial strategy for authenticating people using clever.com to your application using Clever's OAuth2 provider}
-  gem.homepage      = "https://github.com/thinkthroughmath/omniauth-clever"
+  gem.homepage      = "https://github.com/clever/omniauth-clever"
   gem.license       = 'MIT'
 
   gem.signing_key   = ENV['GEM_PRIVATE_KEY']


### PR DESCRIPTION
Thanks to contributions by @thinkthroughmath and @studypad.

Tested using the [omniauth-test-harness](https://github.com/PracticallyGreen/omniauth-test-harness).